### PR TITLE
globals.cssからダークテーマを削除

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,13 +16,3 @@ a {
   padding: 0;
   margin: 0;
 }
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
-}


### PR DESCRIPTION
一部デザインがおかしくなることがあるのでダークテーマ対応を削除します。
ビフォー
<img width="556" alt="スクリーンショット 2023-06-20 20 34 21" src="https://github.com/geekcamp2023-vol2-team31/frontend-2/assets/49736209/528aabfd-edbd-487e-9853-fe593c7d9297">

アフター
<img width="560" alt="スクリーンショット 2023-06-20 20 34 12" src="https://github.com/geekcamp2023-vol2-team31/frontend-2/assets/49736209/9dd6f3a4-a2c7-47c6-923e-435b5365b9b6">
