### PR TITLE
モックサーバ実装

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
   "plugins": [
     "@typescript-eslint"
   ],
+  "ignorePatterns": ["src/mock/server.js"],
   "extends": [
     "next/core-web-vitals",
     "eslint:recommended",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "next-auth": "^4.22.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sass": "^1.63.3",
     "react-sortablejs": "^6.1.4",
+    "sass": "^1.63.3",
     "sortablejs": "^1.15.0",
     "typescript": "^5.0.4"
   },
@@ -41,16 +41,20 @@
     "@storybook/nextjs": "7.0.18",
     "@storybook/react": "7.0.18",
     "@storybook/testing-library": "0.0.14-next.2",
+    "@types/express": "^4.17.17",
     "@types/sortablejs": "^1.15.1",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
+    "body-parser": "^1.20.2",
     "eslint": "^8.40.0",
     "eslint-config-next": "^13.2.4",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-storybook": "^0.6.12",
+    "express": "^4.18.2",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.2",
     "prettier": "^2.8.8",
-    "storybook": "7.0.18"
+    "storybook": "7.0.18",
+    "ts-node": "^10.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "check": "prettier -c \"src/**/*.{tsx,ts,js,json,css,scss}\"",
     "lint:fix": "npm run format&&npm run eslint:fix&&npm run check-types",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "mock-server": "node src/mock/server.js"
   },
   "dependencies": {
     "@sinclair/typebox": "^0.28.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -38,12 +38,12 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
-  sass:
-    specifier: ^1.63.3
-    version: 1.63.3
   react-sortablejs:
     specifier: ^6.1.4
     version: 6.1.4(@types/sortablejs@1.15.1)(react-dom@18.2.0)(react@18.2.0)(sortablejs@1.15.0)
+  sass:
+    specifier: ^1.63.3
+    version: 1.63.3
   sortablejs:
     specifier: ^1.15.0
     version: 1.15.0
@@ -73,6 +73,9 @@ devDependencies:
   '@storybook/testing-library':
     specifier: 0.0.14-next.2
     version: 0.0.14-next.2
+  '@types/express':
+    specifier: ^4.17.17
+    version: 4.17.17
   '@types/sortablejs':
     specifier: ^1.15.1
     version: 1.15.1
@@ -82,6 +85,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: ^5.59.6
     version: 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+  body-parser:
+    specifier: ^1.20.2
+    version: 1.20.2
   eslint:
     specifier: ^8.40.0
     version: 8.40.0
@@ -91,6 +97,9 @@ devDependencies:
   eslint-plugin-storybook:
     specifier: ^0.6.12
     version: 0.6.12(eslint@8.40.0)(typescript@5.0.4)
+  express:
+    specifier: ^4.18.2
+    version: 4.18.2
   husky:
     specifier: ^8.0.3
     version: 8.0.3
@@ -103,6 +112,9 @@ devDependencies:
   storybook:
     specifier: 7.0.18
     version: 7.0.18
+  ts-node:
+    specifier: ^10.9.1
+    version: 10.9.1(@types/node@20.2.0)(typescript@5.0.4)
 
 packages:
 
@@ -2553,6 +2565,13 @@ packages:
     dev: true
     optional: true
 
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
@@ -2921,6 +2940,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@juggle/resize-observer@3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
@@ -4245,6 +4271,22 @@ packages:
       '@testing-library/dom': 8.20.0
     dev: true
 
+  /@tsconfig/node10@1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
   /@types/aria-query@5.0.1:
     resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
     dev: true
@@ -4805,6 +4847,11 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /acorn-walk@8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
@@ -4967,6 +5014,10 @@ packages:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
+    dev: true
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: true
 
   /argparse@1.0.10:
@@ -5293,6 +5344,26 @@ packages:
       on-finished: 2.4.1
       qs: 6.11.0
       raw-body: 2.5.1
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /body-parser@1.20.2:
+    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
     transitivePeerDependencies:
@@ -5874,6 +5945,10 @@ packages:
       sha.js: 2.4.11
     dev: true
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -6124,6 +6199,11 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /diffie-hellman@5.0.3:
@@ -8361,6 +8441,10 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
   /makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
     dependencies:
@@ -9486,6 +9570,16 @@ packages:
       unpipe: 1.0.0
     dev: true
 
+  /raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: true
+
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
@@ -10576,6 +10670,37 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
+  /ts-node@10.9.1(@types/node@20.2.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.2.0
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.0.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /ts-pnp@1.2.0(typescript@5.0.4):
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
@@ -10864,6 +10989,10 @@ packages:
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
+    dev: true
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
 
   /v8-to-istanbul@9.1.0:
@@ -11162,6 +11291,11 @@ packages:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: true
 
   /yocto-queue@0.1.0:

--- a/src/mock/example/teams.http
+++ b/src/mock/example/teams.http
@@ -1,0 +1,118 @@
+## チーム
+### POST /teams
+POST http://localhost:3000/teams
+Content-Type: application/json
+
+{ "team": { "name": "新しいチーム" } }
+
+### GET /teams/:teamId
+GET http://localhost:3000/teams/11
+
+
+### PUT /teams/:teamId
+PUT http://localhost:3000/teams/1
+Content-Type: application/json
+
+{
+  "team": {
+    "name": "新しいチーム名"
+  }
+}
+
+## コメント
+### DELETE /teams/:teamId
+DELETE http://localhost:3000/teams/1
+
+### GET /teams/:teamId/comments
+GET http://localhost:3000/teams/1/comments
+
+### POST /teams/:teamId/comments
+POST http://localhost:3000/teams/1/comments
+Content-Type: application/json
+
+{
+  "comment": {
+    "content": "アイディア",
+    "columnId": "3"
+  }
+}
+
+### PUT /teams/:teamId/comments/:commentId
+PUT http://localhost:3000/teams/1/comments/1
+Content-Type: application/json
+
+{
+  "comment": {
+    "content": "名前変更後のアイディア"
+  }
+}
+
+
+### DELETE /teams/:teamId/comments/:commentId
+DELETE http://localhost:3000/teams/1/comments/1
+
+## プロダクト
+### GET /teams/:teamId/products
+GET http://localhost:3000/teams/1/products
+
+### POST /teams/:teamId/products
+POST http://localhost:3000/teams/1/products
+Content-Type: application/json
+
+{
+  "product": {
+    "name": "プロダクト1",
+    "comments": [
+      {
+        "id": "4",
+        "content": "コメント4",
+        "columnId": "3"
+      },
+      {
+        "id": "5",
+        "content": "コメント5",
+        "columnId": "3"
+      }
+    ]
+  }
+}
+
+### PUT /teams/:teamId/products/:productId
+PUT http://localhost:3000/teams/1/products/1
+Content-Type: application/json
+
+{
+  "product": {
+    "name": "プロダクト1",
+    "comments": [
+      {
+        "id": "5",
+        "content": "コメント5",
+        "columnId": "3"
+      }
+    ],
+    "techs": [
+      {
+        "name": "JavaScript"
+      }
+    ]
+  }
+}
+
+## リンク（コメント間の直線）
+### GET /teams/:teamId/links/
+GET http://localhost:3000/teams/1/links
+
+### POST /teams/:teamId/links/
+POST http://localhost:3000/teams/1/links
+Content-Type: application/json
+
+{
+  "link": {
+    "left": { "commentId": "3" },
+    "right": { "commentId": "5" }
+  }
+}
+
+### DELETE /teams/:teamId/links/1
+DELETE http://localhost:3000/teams/1/links/1

--- a/src/mock/example/teams.http
+++ b/src/mock/example/teams.http
@@ -6,7 +6,7 @@ Content-Type: application/json
 { "team": { "name": "新しいチーム" } }
 
 ### GET /teams/:teamId
-GET http://localhost:3000/teams/11
+GET http://localhost:3000/teams/1
 
 
 ### PUT /teams/:teamId
@@ -65,13 +65,13 @@ Content-Type: application/json
     "comments": [
       {
         "id": "4",
-        "content": "コメント4",
-        "columnId": "3"
+        "value": "コメント4",
+        "type": "solution"
       },
       {
         "id": "5",
-        "content": "コメント5",
-        "columnId": "3"
+        "value": "コメント5",
+        "type": "solution"
       }
     ]
   }
@@ -87,8 +87,8 @@ Content-Type: application/json
     "comments": [
       {
         "id": "5",
-        "content": "コメント5",
-        "columnId": "3"
+        "value": "コメント5",
+        "type": "solution"
       }
     ],
     "techs": [
@@ -109,8 +109,8 @@ Content-Type: application/json
 
 {
   "link": {
-    "left": { "commentId": "3" },
-    "right": { "commentId": "5" }
+    "left": { "id": "3", "value": "コメント3", "type": "goal" },
+    "right": { "id": "5", "value": "コメント5", "type": "solution" }
   }
 }
 

--- a/src/mock/example/techs.http
+++ b/src/mock/example/techs.http
@@ -1,0 +1,12 @@
+### GET /techs
+GET http://localhost:3000/techs
+
+### PUT /techs
+PUT http://localhost:3000/techs/Java
+Content-Type: application/json
+
+{
+  "tech": {
+    "icon": "<JAVA_ICON_URL>"
+  }
+}

--- a/src/mock/example/users.http
+++ b/src/mock/example/users.http
@@ -1,0 +1,29 @@
+### GET /users/me
+GET http://localhost:3000/users/me
+
+### PUT /users/me
+PUT http://localhost:3000/users/me
+Content-Type: application/json
+
+{
+    "user": {
+        "id": "1",
+        "name": "Yamada 1Taro",
+        "bio": "Yamadaです。お願いします",
+        "techs": [
+            {
+                "id": "1",
+                "name": "TypeScript",
+                "level": "beginner"
+            },
+            {
+                "id": "2",
+                "name": "JavaScript",
+                "level": "expert"
+            }
+        ]
+    }
+}
+
+### PUT /users/me/teams/:invitationCode
+PUT http://localhost:3000/users/me/teams/dummy_code

--- a/src/mock/server.js
+++ b/src/mock/server.js
@@ -1,0 +1,367 @@
+const express = require("express");
+const bodyParser = require("body-parser");
+const app = express();
+
+app.use(
+  bodyParser.urlencoded({
+    extended: true,
+  })
+);
+app.use(bodyParser.json());
+
+const port = 3000;
+
+const log = (msg) => {
+  console.log("DEBUG @mock:", msg);
+};
+// ↓ ダミーデータの宣言 ↓
+let techs = [{ name: "TypeScript" }, { name: "JavaScript" }, { name: "Java" }];
+
+let teams = [
+  {
+    id: "1",
+    invitationCode: "INVITATION_CODE_1",
+    name: "team1",
+  },
+  {
+    id: "2",
+    invitationCode: "INVITATION_CODE_2",
+    name: "team2",
+  },
+];
+
+const user = {
+  icon: undefined,
+  id: "1",
+  name: "Yamada Taro",
+  bio: "Yamadaです。お願いします",
+  techs: [
+    { ...techs[0], level: "beginner" },
+    { ...techs[1], level: "expert" },
+  ],
+  owns: [teams[0]],
+  belongs: [teams[1]],
+};
+
+const newTeam = { id: "3", name: "teamAdded", invitationCode: "CODE3" };
+
+const uniqueId = (() => {
+  let count = 10;
+  return () => {
+    count++;
+    return count.toString();
+  };
+})();
+
+let comments = [
+  { id: "1", content: "コメント1", columnId: "1" },
+  { id: "2", content: "コメント2", columnId: "1" },
+  { id: "3", content: "コメント3", columnId: "2" },
+  { id: "4", content: "コメント4", columnId: "3" },
+  { id: "5", content: "コメント5", columnId: "3" },
+];
+
+let products = [
+  {
+    id: "1",
+    name: "プロダクト1",
+    comments: [comments[3], comments[4]],
+    techs: [techs[0]],
+  },
+];
+
+let links = [
+  { id: "1", left: { commentId: "1" }, right: { commentId: "3" } },
+  { id: "2", left: { commentId: "3" }, right: { commentId: "4" } },
+];
+// ↑ ダミーデータの宣言 ↑
+
+// POST /auth
+app.post("/auth", (req, res) => {
+  // tokenの有無に関わらず成功する
+  const token = req.body.token;
+  log(`token is ${token}`);
+  res.send({
+    type: "AuthResponse",
+    status: "200",
+    message: "login success",
+    isFirstLogin: false,
+  });
+});
+
+// GET /users/me
+// Response: IGetUsersMeResponse
+app.get("/users/me", (req, res) => {
+  res.send({ user });
+});
+
+// PUT /users/me
+// Response: IGetUsersMeResponse
+app.put("/users/me", (req, res) => {
+  const {
+    user: { icon, name, bio, techs },
+  } = req.body;
+  user.icon = icon;
+  user.name = name;
+  user.bio = bio;
+  user.techs = techs;
+  res.send("success");
+});
+
+// PUT /users/me/teams/:invitationCode]
+app.put("/users/me/teams/:invitationCode", (req, res) => {
+  user.belongs.push(newTeam);
+  res.send("successs");
+});
+
+// POST /teams
+// Request: IPostTeamsBody
+// Response: IPostTeamsResponse | UnauthorizedError
+// ここでは常に成功する
+app.post("/teams", (req, res) => {
+  log({ bod: req.body });
+  const {
+    team: { name },
+  } = req.body;
+  const id = uniqueId();
+  user.owns.push({ id, name });
+  teams.push({ id, name });
+  res.send({
+    team: {
+      invitationCode: "INVITATION_CODE_DUMMY",
+      id,
+      name,
+      owner: {
+        icon: user.icon,
+        id: user.id,
+        name: user.name,
+        bio: user.bio,
+      },
+      members: [
+        {
+          icon: user.icon,
+          id: user.id,
+          name: user.name,
+          bio: user.bio,
+        },
+      ],
+    },
+  });
+});
+
+// GET /teams/:teamId
+// Request: ITeamGetParams
+// Response: ITeamGetResponse
+app.get("/teams/:teamId", (req, res) => {
+  const team = teams.find((t) => t.id === req.params.teamId);
+  if (!team) {
+    res.status(404).send();
+    return;
+  }
+  // teamIdに関わらす１つ目を返す
+  res.send({
+    team: {
+      ...team,
+      invitationCode: "INVITATION_CODE_DUMMY",
+      owner: {
+        icon: user.icon,
+        id: user.id,
+        name: user.name,
+        bio: user.bio,
+      },
+      members: [
+        {
+          icon: user.icon,
+          id: user.id,
+          name: user.name,
+          bio: user.bio,
+        },
+      ],
+    },
+  });
+});
+
+// PUT /teams/:teamId
+// Request: ITeamPutBody(実装時点で未定)
+// Response: ITeamPutResponse(実装時点で未定)
+app.put("/teams/:teamId", (req, res) => {
+  const teamId = req.params.teamId;
+  const { team } = req.body;
+  teams = teams.map((t) => (t.id === teamId ? { ...t, ...team } : t));
+  res.send("success");
+});
+
+// DELETE /teams/:teamId
+app.delete("/teams/:teamId", (req, res) => {
+  const teamId = req.params.teamId;
+  teams = teams.filter((t) => t.id !== teamId);
+  user.owns = user.owns.filter((t) => t.id !== teamId);
+  user.belongs = user.belongs.filter((t) => t.id !== teamId);
+  res.send("success");
+});
+
+// GET /teams/:teamId/comments
+/**
+ *  Response(暫定): {
+ *    comments: {
+ *      id: string;
+ *      content: string;
+ *      columnId: "1" | "2" | "3";
+ *    }[];
+ *  }
+ */
+app.get("/teams/:teamId/comments", (req, res) => {
+  res.send({ comments });
+});
+
+// POST /teams/:teamId/comments
+/**
+ *  Request(暫定): {
+ *    comment: {
+ *      content: string;
+ *      columnId: "1" | "2" | "3";
+ *    };
+ *  }
+ */
+app.post("/teams/:teamId/comments", (req, res) => {
+  const {
+    comment: { content, columnId },
+  } = req.body;
+  comments.push({ id: uniqueId, content, columnId });
+  res.send("success");
+});
+
+// PUT /teams/:teamId/comments/:commentId
+/**
+ *  Request(暫定): {
+ *    comment: {
+ *      content: string;
+ *    };
+ *  }
+ */
+app.put("/teams/:teamId/comments/:commentId", (req, res) => {
+  const commentId = req.params.commentId;
+  comments = comments.map((c) =>
+    c.id === commentId ? { ...c, content: req.body.comment.content } : c
+  );
+  res.send("success");
+});
+
+// DELETE /teams/:teamId/comments/:commentId
+app.delete("/teams/:teamId/comments/:commentId", (req, res) => {
+  const commentId = req.params.commentId;
+  comments = comments.filter((c) => c.id !== commentId);
+  res.send("success");
+});
+
+// GET /teams/:teamId/products
+/**
+ * Response(暫定): {
+ *   products: {
+ *     id: string;
+ *     name: string;
+ *     comments: Comment[];
+ *     techs: { name: string; icon?: string }[]; // 使用技術
+ *   };
+ * }
+ */
+app.get("/teams/:teamId/products", (req, res) => {
+  res.send({ products });
+});
+
+// POST /teams/:teamId/products
+/**
+ * Request(暫定): {
+ *   product: {
+ *     name: string;
+ *     comments: Comment[];
+ *   };
+ * }
+ */
+app.post("/teams/:teamId/products", (req, res) => {
+  const {
+    product: { name, comments },
+  } = req.body;
+  products.push({ id: uniqueId(), name, comments });
+  res.send("success");
+});
+
+// PUT /teams/:teamId/products/:productId
+/**
+ * Request(暫定): {
+ *   product: {
+ *     name: string;
+ *     comments: Comment[];
+ *     techs: { name: string; icon?: string; }[];
+ *   };
+ * }
+ */
+app.put("/teams/:teamId/products/:productId", (req, res) => {
+  const productId = req.params.productId;
+  const {
+    product: { name, comments, techs },
+  } = req.body;
+  products = products.map((p) =>
+    p.id === productId ? { ...p, name, comments, techs } : p
+  );
+  res.send("success");
+});
+
+// GET /teams/:teamId/links
+/**
+ * Response(暫定): {
+ *   links: {
+ *     id: string;
+ *     left: { commentId: string };
+ *     right: { commentId: string };
+ *   }[];
+ * }
+ */
+app.get("/teams/:teamId/links", (req, res) => {
+  res.send({ links });
+});
+
+// POST /teams/:teamId/links
+/**
+ * Request(暫定): {
+ *   link: {
+ *     left: { commentId: string };
+ *     right: { commentId: string };
+ *   };
+ * }
+ */
+app.post("/teams/:teamId/links", (req, res) => {
+  const { link } = req.body;
+  const newLink = { id: uniqueId(), ...link };
+  links.push(newLink);
+  res.send(newLink);
+});
+
+// DELETE /teams/:teamId/links/:linkId
+app.delete("/teams/:teamId/links/:linkId", (req, res) => {
+  const linkId = req.params.linkId;
+  links = links.filter((l) => l.id !== linkId);
+  res.send("success");
+});
+
+// GET /techs
+// Response: IGetTechAllResopnse
+app.get("/techs", (req, res) => {
+  res.send({ techs });
+});
+
+// PUT /techs/:techName
+// Request: IPutTechBody
+// 現状アイコンの変更以外には使えない
+app.put("/techs/:techName", (req, res) => {
+  const techName = req.params.techName;
+  const {
+    tech: { icon },
+  } = req.body;
+  techs = techs.filter((t) => (t.name === techName ? { ...t, icon } : t));
+  res.send("success");
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/src/mock/server.js
+++ b/src/mock/server.js
@@ -53,12 +53,19 @@ const uniqueId = (() => {
   };
 })();
 
+/**
+ * interface IComment {
+ *   id: string;
+ *   value: string;
+ *   type: "problems" | "goals" | "solutions";
+ * }
+ */
 let comments = [
-  { id: "1", content: "コメント1", columnId: "1" },
-  { id: "2", content: "コメント2", columnId: "1" },
-  { id: "3", content: "コメント3", columnId: "2" },
-  { id: "4", content: "コメント4", columnId: "3" },
-  { id: "5", content: "コメント5", columnId: "3" },
+  { id: "1", value: "コメント1", type: "problem" },
+  { id: "2", value: "コメント2", type: "problem" },
+  { id: "3", value: "コメント3", type: "goal" },
+  { id: "4", value: "コメント4", type: "solution" },
+  { id: "5", value: "コメント5", type: "solution" },
 ];
 
 let products = [
@@ -71,8 +78,8 @@ let products = [
 ];
 
 let links = [
-  { id: "1", left: { commentId: "1" }, right: { commentId: "3" } },
-  { id: "2", left: { commentId: "3" }, right: { commentId: "4" } },
+  { id: "1", left: comments[0], right: comments[2] },
+  { id: "2", left: comments[2], right: comments[3] },
 ];
 // ↑ ダミーデータの宣言 ↑
 
@@ -205,8 +212,8 @@ app.delete("/teams/:teamId", (req, res) => {
  *  Response(暫定): {
  *    comments: {
  *      id: string;
- *      content: string;
- *      columnId: "1" | "2" | "3";
+ *      value: string;
+ *      type: "problem" | "goal" | "solution";
  *    }[];
  *  }
  */
@@ -219,7 +226,8 @@ app.get("/teams/:teamId/comments", (req, res) => {
  *  Request(暫定): {
  *    comment: {
  *      content: string;
- *      columnId: "1" | "2" | "3";
+ *      value: string;
+ *      type: "problem" | "goal" | "solution";
  *    };
  *  }
  */
@@ -235,7 +243,7 @@ app.post("/teams/:teamId/comments", (req, res) => {
 /**
  *  Request(暫定): {
  *    comment: {
- *      content: string;
+ *      value: string;
  *    };
  *  }
  */
@@ -312,8 +320,8 @@ app.put("/teams/:teamId/products/:productId", (req, res) => {
  * Response(暫定): {
  *   links: {
  *     id: string;
- *     left: { commentId: string };
- *     right: { commentId: string };
+ *     left: Comment;
+ *     right: Comment;
  *   }[];
  * }
  */
@@ -325,8 +333,8 @@ app.get("/teams/:teamId/links", (req, res) => {
 /**
  * Request(暫定): {
  *   link: {
- *     left: { commentId: string };
- *     right: { commentId: string };
+ *     left: Comment;
+ *     right: Comment;
  *   };
  * }
  */


### PR DESCRIPTION
ローカルでフロントエンドのAPIリクエストを確認することを目的としてモックサーバを実装しました。
[現行のAPI仕様](https://scrapbox.io/geekcomp/%E6%8A%80%E8%82%B2%E3%82%AB%E3%83%B3%E3%83%97:_API%E4%BB%95%E6%A7%98%E6%9B%B8) の全エンドポイントに加えて、リンクに関するリクエストを暫定で実装しています:
- GET /teams/:teamId/links
- POST /teams/:teamId/links
- DELETE /teams/:teamId/links/:linkId

注意:
- 認証を正しく行う機能はありません。常に認証に成功します。
- フロントエンドの動作確認を目的としているので、teamのidに関わらず同じ内容を返すなど、一部正しいバックエンドと異なる動作をします。
- リクエスト/レスポンスの型が型リポジトリとずれる可能性があります。その場合は型リポジトリが正しく、モックの内容を合わせる必要があります。

環境構築
`pnpm i`
モックサーバ実行
`pnpm mock-server`
http://localhost:3000 でサーバが立ち上がります。

リクエストのサンプル
src/mock/example/*.http が各リクエストのサンプルです。
VSCodeであれば`REST Client` プラグインを入れると実際にリクエストを送れます。
たしか IntelliJ はデフォルトでサポートしています。

